### PR TITLE
remove UNKNOWN status to avoid error when subnet creation is too long

### DIFF
--- a/flexibleengine/resource_flexibleengine_vpc_subnet_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_subnet_v1.go
@@ -264,7 +264,7 @@ func waitForVpcSubnetActive(subnetClient *golangsdk.ServiceClient, vpcId string)
 		}
 
 		//If subnet status is other than Active, send error
-		if n.Status == "DOWN" || n.Status == "ERROR" || n.Status == "UNKNOWN" {
+		if n.Status == "DOWN" || n.Status == "ERROR" {
 			return nil, "", fmt.Errorf("Subnet status: '%s'", n.Status)
 		}
 


### PR DESCRIPTION
When this resource is used with a list variable that contains many subnets description, terraform exits with an error because all subnets are not created and the status is unknown.

`locals {
  subnets = [
    {
      subnet_name       = "private_1"
      subnet_cidr       = "10.20.2.0/24"
      subnet_gateway_ip = "10.20.2.1"
    },
    {
      subnet_name       = "private_2"
      subnet_cidr       = "10.20.3.0/24"
      subnet_gateway_ip = "10.20.3.1"
    },
    {
      subnet_name       = "private_3"
      subnet_cidr       = "10.20.4.0/24"
      subnet_gateway_ip = "10.20.4.1"
    },
  ]
}

resource "flexibleengine_vpc_subnet_v1" "subnet" {
count = "length(local.subnets) > 0 ? length(local.subnets) : 0}"

  name          = "${lookup(local.subnets[count.index], "subnet_name")}"
  cidr          = "${lookup(local.subnets[count.index], "subnet_cidr")}"
  gateway_ip    = "${lookup(local.subnets[count.index], "subnet_gateway_ip")}"
  vpc_id        = "${flexibleengine_vpc_v1.vpc.id}"
}`

This issue occurs when the subnet list contains more than 2 subnets.