### PR TITLE
Fix LB Pool stuck issue

### DIFF
--- a/flexibleengine/resource_flexibleengine_lb_pool_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_pool_v2.go
@@ -196,13 +196,7 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Attempting to create pool")
 	var pool *pools.Pool
-	err = resource.Retry(timeout, func() *resource.RetryError {
-		pool, err = pools.Create(networkingClient, createOpts).Extract()
-		if err != nil {
-			return checkForRetryableError(err)
-		}
-		return nil
-	})
+	pool, err = pools.Create(networkingClient, createOpts).Extract()
 
 	if err != nil {
 		return fmt.Errorf("Error creating pool: %s", err)


### PR DESCRIPTION
This removes the retryable error check as we keep receiving 409 from server side if protocol mismatch with listener.

fixes #165 