### PR TITLE
Update cce_cluster_v3.html.md

### DIFF
--- a/website/docs/r/cce_cluster_v3.html.md
+++ b/website/docs/r/cce_cluster_v3.html.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) The ID of the VPC used to create the node. Changing this parameter will create a new cluster resource.
 
-* `subnet_id` - (Required) The ID of the subnet used to create the node. Changing this parameter will create a new cluster resource.
+* `subnet_id` - (Required) The NETWORK ID of the subnet used to create the node. Changing this parameter will create a new cluster resource.
 
 * `highway_subnet_id` - (Optional) The ID of the high speed network used to create bare metal nodes. Changing this parameter will create a new cluster resource.
 


### PR DESCRIPTION
CCE is created based on the network id instead of subnet id directly. the name of the parameter may mislead users. We need to point this point first. And later discuss is there is anything that we need to change from the API side