### PR TITLE
Prepare to SDK migration

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/pathorcontents"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform/httpclient"
 	"github.com/huaweicloud/golangsdk"
 	huaweisdk "github.com/huaweicloud/golangsdk/openstack"
 	"github.com/huaweicloud/golangsdk/openstack/objectstorage/v1/swauth"
@@ -42,6 +42,7 @@ type Config struct {
 	Token            string
 	Username         string
 	UserID           string
+	terraformVersion string
 
 	HwClient *golangsdk.ProviderClient
 	s3sess   *session.Session
@@ -104,7 +105,7 @@ func newhwClient(c *Config) error {
 	}
 
 	// Set UserAgent
-	client.UserAgent.Prepend(terraform.UserAgentString())
+	client.UserAgent.Prepend(httpclient.TerraformUserAgent(c.terraformVersion))
 
 	config := &tls.Config{}
 	if c.CACertFile != "" {


### PR DESCRIPTION
Remove deprecated terraform helpers to get UserAgent.
Add terraformVersion to provider config.