### PR TITLE
Log fault message when build compute instance failed

### DIFF
--- a/flexibleengine/resource_flexibleengine_compute_instance_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2.go
@@ -833,6 +833,11 @@ func ServerV2StateRefreshFunc(client *golangsdk.ServiceClient, instanceID string
 			return nil, "", err
 		}
 
+		// get fault message when status is ERROR
+		if s.Status == "ERROR" {
+			fault := fmt.Errorf("[error code: %d, message: %s]", s.Fault.Code, s.Fault.Message)
+			return s, "ERROR", fault
+		}
 		return s, s.Status, nil
 	}
 }


### PR DESCRIPTION
we can get the error message in the fault field of querying response body.
This patch prepare to fix #254 