### PR TITLE
Support 'tls_ciphers_policy' in flexibleengine_lb_listener_v2 resource

### DIFF
--- a/flexibleengine/resource_flexibleengine_lb_listener_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2.go
@@ -93,14 +93,17 @@ func resourceListenerV2() *schema.Resource {
 			"default_tls_container_ref": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"sni_container_refs": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				ForceNew: true,
+			},
+
+			"tls_ciphers_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"admin_state_up": {
@@ -137,6 +140,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		Description:            d.Get("description").(string),
 		DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
 		SniContainerRefs:       sniContainerRefs,
+		TlsCiphersPolicy:       d.Get("tls_ciphers_policy").(string),
 		AdminStateUp:           &adminStateUp,
 	}
 
@@ -205,6 +209,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 	if err := d.Set("sni_container_refs", listener.SniContainerRefs); err != nil {
 		return fmt.Errorf("[DEBUG] Error saving sni_container_refs to state for FlexibleEngine listener (%s): %s", d.Id(), err)
 	}
+	d.Set("tls_ciphers_policy", listener.TlsCiphersPolicy)
 	d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
 	d.Set("region", GetRegion(d, config))
 
@@ -240,6 +245,9 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 			}
 		}
 		updateOpts.SniContainerRefs = sniContainerRefs
+	}
+	if d.HasChange("tls_ciphers_policy") {
+		updateOpts.TlsCiphersPolicy = d.Get("tls_ciphers_policy").(string)
 	}
 	if d.HasChange("admin_state_up") {
 		asu := d.Get("admin_state_up").(bool)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20191210073300-45934317f587
+	github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huaweicloud/golangsdk v0.0.0-20191210073300-45934317f587 h1:0OjF+a0EUAKCX7SKexPEQvAt3fTE9cccP6c8PBqHFiY=
-github.com/huaweicloud/golangsdk v0.0.0-20191210073300-45934317f587/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f h1:y8jF+j+IW/HbPRnVA6TVnmCVFlp7eWNQJZq9Zxl6g1E=
+github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -112,6 +112,9 @@ type CreateOpts struct {
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
 
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
+
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
@@ -167,6 +170,9 @@ type UpdateOpts struct {
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
 
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -50,6 +50,9 @@ type Listener struct {
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref"`
 
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy"`
+
 	// The administrative state of the Listener. A valid value is true (UP) or false (DOWN).
 	AdminStateUp bool `json:"admin_state_up"`
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/hashicorp/terraform-plugin-sdk/internal/svchost
 github.com/hashicorp/terraform-plugin-sdk/internal/svchost/auth
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20191210073300-45934317f587
+# github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/openstack
 github.com/huaweicloud/golangsdk/openstack/antiddos/v1/antiddos

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -61,7 +61,7 @@ nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
 -----END RSA PRIVATE KEY-----
 EOT
 
-certificate = <<EOT
+  certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
 BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
@@ -137,6 +137,37 @@ The following arguments are supported:
     [here](https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer)
     for more information.
 
+* `tls_ciphers_policy` - (Optional) Specifies the security policy used by the listener.
+    This parameter is valid only when the load balancer protocol is set to TERMINATED_HTTPS.
+    The value can be tls-1-0, tls-1-1, tls-1-2, or tls-1-2-strict, and the default value is tls-1-0.
+    For details of cipher suites for each security policy, see the table below.
+
+<table>
+  <tr>
+    <th>Security Policy</th>
+    <th>TLS Version</th>
+    <th>Cipher Suite</th>
+  </tr >
+  <tr >
+    <td>tls-1-0</td>
+    <td>TLSv1.2 TLSv1.1 TLSv1</td>
+    <td rowspan="3">ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:AES128-SHA256:AES256-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:AES128-SHA:AES256-SHA</td>
+  </tr>
+  <tr>
+    <td>tls-1-1</td>
+    <td>TLSv1.2 TLSv1.1</td>
+  </tr>
+  <tr>
+    <td>tls-1-2</td>
+    <td>TLSv1.2</td>
+  </tr>
+  <tr>
+    <td >tls-1-2-strict</td>
+    <td >TLSv1.2</td>
+    <td >ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:AES128-GCM-SHA256:AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:AES128-SHA256:AES256-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384</td>
+  </tr>
+</table>
+
 * `admin_state_up` - (Optional) The administrative state of the Listener.
     A valid value is true (UP) or false (DOWN).
 
@@ -154,4 +185,5 @@ The following attributes are exported:
 * `connection_limit` - See Argument Reference above.
 * `default_tls_container_ref` - See Argument Reference above.
 * `sni_container_refs` - See Argument Reference above.
+* `tls_ciphers_policy` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.


### PR DESCRIPTION
'tls_ciphers_policy' was available in lb_listerner_v2 API, and we  implement it on Teraform.
fix #280 