### PR TITLE
Add flexibleengine_sdrs_replication_pair_v1 resource and docs

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -285,6 +285,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_cce_cluster_v3":                     resourceCCEClusterV3(),
 			"flexibleengine_dds_instance_v3":                    resourceDdsInstanceV3(),
 			"flexibleengine_sdrs_protectiongroup_v1":            resourceSdrsProtectiongroupV1(),
+			"flexibleengine_sdrs_replication_pair_v1":           resourceSdrsReplicationPairV1(),
 		},
 	}
 

--- a/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1.go
@@ -1,0 +1,199 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications"
+)
+
+func resourceSdrsReplicationPairV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceSdrsReplicationPairV1Create,
+		Read:   resourceSdrsReplicationPairV1Read,
+		Update: resourceSdrsReplicationPairV1Update,
+		Delete: resourceSdrsReplicationPairV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"volume_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			// used for delete
+			"delete_target_volume": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: false,
+			},
+			// the following attributes are computed
+			"replication_model": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fault_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"target_volume_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceSdrsReplicationPairV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	sdrsClient, err := config.sdrsV1Client(GetRegion(d, config))
+
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine SDRS Client: %s", err)
+	}
+
+	createOpts := replications.CreateOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		GroupID:     d.Get("group_id").(string),
+		VolumeID:    d.Get("volume_id").(string),
+	}
+	log.Printf("[DEBUG] CreateOpts: %#v", createOpts)
+
+	n, err := replications.Create(sdrsClient, createOpts).ExtractJobResponse()
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine SDRS Replication pair: %s", err)
+	}
+
+	if err := replications.WaitForJobSuccess(sdrsClient, int(d.Timeout(schema.TimeoutCreate)/time.Second), n.JobID); err != nil {
+		return err
+	}
+
+	entity, err := replications.GetJobEntity(sdrsClient, n.JobID, "replication_pair_id")
+	if err != nil {
+		return err
+	}
+
+	if id, ok := entity.(string); ok {
+		d.SetId(id)
+		return resourceSdrsReplicationPairV1Read(d, meta)
+	}
+
+	return fmt.Errorf("Unexpected conversion error in resourceSdrsReplicationPairV1Create.")
+}
+
+func resourceSdrsReplicationPairV1Read(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+	sdrsClient, err := config.sdrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine SDRS client: %s", err)
+	}
+	n, err := replications.Get(sdrsClient, d.Id()).Extract()
+
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Error retrieving FlexibleEngine SDRS Replication pair: %s", err)
+	}
+
+	d.Set("name", n.Name)
+	d.Set("description", n.Description)
+	d.Set("group_id", n.GroupID)
+	d.Set("status", n.Status)
+	d.Set("replication_model", n.ReplicaModel)
+	d.Set("fault_level", n.FaultLevel)
+
+	// set "volume_id" and "target_volume_id" from VolumeIDs
+	volumes := strings.Split(n.VolumeIDs, ",")
+	if len(volumes) < 2 {
+		return fmt.Errorf("Error retrieving VolumeIDs od FlexibleEngine SDRS Replication pair: Invalid format.")
+	}
+	d.Set("volume_id", volumes[0])
+	d.Set("target_volume_id", volumes[1])
+
+	return nil
+}
+
+func resourceSdrsReplicationPairV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	sdrsClient, err := config.sdrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine SDRS Client: %s", err)
+	}
+	var updateOpts replications.UpdateOpts
+
+	if d.HasChange("name") {
+		updateOpts.Name = d.Get("name").(string)
+	}
+	log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
+
+	_, err = replications.Update(sdrsClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating FlexibleEngine SDRS Replication pair: %s", err)
+	}
+	return resourceSdrsReplicationPairV1Read(d, meta)
+}
+
+func resourceSdrsReplicationPairV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	sdrsClient, err := config.sdrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine SDRS client: %s", err)
+	}
+
+	deleteOpts := replications.DeleteOpts{
+		GroupID:      d.Get("group_id").(string),
+		DeleteVolume: d.Get("delete_target_volume").(bool),
+	}
+	n, err := replications.Delete(sdrsClient, d.Id(), deleteOpts).ExtractJobResponse()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine SDRS Replication pair: %s", err)
+	}
+
+	if err := replications.WaitForJobSuccess(sdrsClient, int(d.Timeout(schema.TimeoutDelete)/time.Second), n.JobID); err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1_test.go
@@ -1,0 +1,149 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications"
+)
+
+func TestAccSdrsReplicationPairV1_basic(t *testing.T) {
+	var repPair replications.Replication
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheckSdrs(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSdrsReplicationPairV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSdrsReplicationPairV1_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSdrsReplicationPairV1Exists("flexibleengine_sdrs_replication_pair_v1.replication_1", &repPair),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sdrs_replication_pair_v1.replication_1", "name", "replication_1"),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sdrs_replication_pair_v1.replication_1", "status", "available"),
+				),
+			},
+			{
+				Config: testAccSdrsReplicationPairV1_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSdrsReplicationPairV1Exists("flexibleengine_sdrs_replication_pair_v1.replication_1", &repPair),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sdrs_replication_pair_v1.replication_1", "name", "replication_updated"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckSdrsReplicationPairV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	sdrsClient, err := config.sdrsV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine SDRS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_sdrs_replication_pair_v1" {
+			continue
+		}
+
+		_, err := replications.Get(sdrsClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("SDRS replication pair still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckSdrsReplicationPairV1Exists(n string, pair *replications.Replication) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		sdrsClient, err := config.sdrsV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine SDRS client: %s", err)
+		}
+
+		found, err := replications.Get(sdrsClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("SDRS replication pair not found")
+		}
+
+		*pair = *found
+		return nil
+	}
+}
+
+var testAccSdrsReplicationPairV1_basic = fmt.Sprintf(`
+data "flexibleengine_sdrs_domain_v1" "domain_1" {
+  name = "SDRS_HypeDomain01"
+}
+
+resource "flexibleengine_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  description = "volume for replication pair"
+  availability_zone = "eu-west-0a"
+  size = 10
+}
+resource "flexibleengine_sdrs_protectiongroup_v1" "group_1" {
+  name = "group_1"
+  description = "test description"
+  source_availability_zone = "eu-west-0a"
+  target_availability_zone = "eu-west-0b"
+  domain_id = data.flexibleengine_sdrs_domain_v1.domain_1.id
+  source_vpc_id = "%s"
+  dr_type = "migration"
+}
+resource "flexibleengine_sdrs_replication_pair_v1" "replication_1" {
+  name = "replication_1"
+  description = "test replication pair"
+  group_id = flexibleengine_sdrs_protectiongroup_v1.group_1.id
+  volume_id = flexibleengine_blockstorage_volume_v2.volume_1.id
+  delete_target_volume = true
+}`, OS_VPC_ID)
+
+var testAccSdrsReplicationPairV1_update = fmt.Sprintf(`
+data "flexibleengine_sdrs_domain_v1" "domain_1" {
+  name = "SDRS_HypeDomain01"
+}
+
+resource "flexibleengine_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  description = "volume for replication pair"
+  availability_zone = "eu-west-0a"
+  size = 10
+}
+resource "flexibleengine_sdrs_protectiongroup_v1" "group_1" {
+  name = "group_1"
+  description = "test description"
+  source_availability_zone = "eu-west-0a"
+  target_availability_zone = "eu-west-0b"
+  domain_id = data.flexibleengine_sdrs_domain_v1.domain_1.id
+  source_vpc_id = "%s"
+  dr_type = "migration"
+}
+resource "flexibleengine_sdrs_replication_pair_v1" "replication_1" {
+  name = "replication_updated"
+  description = "test replication pair"
+  group_id = flexibleengine_sdrs_protectiongroup_v1.group_1.id
+  volume_id = flexibleengine_blockstorage_volume_v2.volume_1.id
+  delete_target_volume = true
+}`, OS_VPC_ID)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f
+	github.com/huaweicloud/golangsdk v0.0.0-20200121072916-971bfff40713
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f h1:y8jF+j+IW/HbPRnVA6TVnmCVFlp7eWNQJZq9Zxl6g1E=
-github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20200121072916-971bfff40713 h1:wZ9LWzmdq5mQknXpUkuT+8AGp+tv/yMKGAMgF+KyJkw=
+github.com/huaweicloud/golangsdk v0.0.0-20200121072916-971bfff40713/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/requests.go
@@ -1,0 +1,110 @@
+package replications
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToReplicationCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new replication.
+type CreateOpts struct {
+	//Protection Group ID
+	GroupID string `json:"server_group_id" required:"true"`
+	//Volume ID
+	VolumeID string `json:"volume_id" required:"true"`
+	//Replication Name
+	Name string `json:"name" required:"true"`
+	//Replication Description
+	Description string `json:"description,omitempty"`
+}
+
+// ToReplicationCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToReplicationCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "replication")
+}
+
+// Create will create a new Replication based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r JobResult) {
+	b, err := opts.ToReplicationCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToReplicationUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a Replication.
+type UpdateOpts struct {
+	//Replication name
+	Name string `json:"name" required:"true"`
+}
+
+// ToReplicationUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToReplicationUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "replication")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a Replication.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToReplicationUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, id), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular Replication based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, &RequestOpts)
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// Delete request.
+type DeleteOptsBuilder interface {
+	ToReplicationDeleteMap() (map[string]interface{}, error)
+}
+
+// DeleteOpts contains all the values needed to delete a Replication.
+type DeleteOpts struct {
+	//Group ID
+	GroupID string `json:"server_group_id,omitempty"`
+	//Delete Target Volume
+	DeleteVolume bool `json:"delete_target_volume,omitempty"`
+}
+
+// ToReplicationDeleteMap builds a update request body from DeleteOpts.
+func (opts DeleteOpts) ToReplicationDeleteMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "replication")
+}
+
+// Delete will permanently delete a particular Replication based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r JobResult) {
+	b, err := opts.ToReplicationDeleteMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.DeleteWithBodyResp(resourceURL(c, id), b, &r.Body, reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/results.go
@@ -1,0 +1,75 @@
+package replications
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type Replication struct {
+	//Replication ID
+	Id string `json:"id"`
+	//Replication Name
+	Name string `json:"name"`
+	//Replication Description
+	Description string `json:"description"`
+	//Replication Model
+	ReplicaModel string `json:"replication_model"`
+	//Replication Status
+	Status string `json:"status"`
+	//Replication Attachment
+	Attachment []Attachment `json:"attachment"`
+	//Replication Group ID
+	GroupID string `json:"server_group_id"`
+	//Replication Volume IDs
+	VolumeIDs string `json:"volume_ids"`
+	//Replication Priority Station
+	PriorityStation string `json:"priority_station"`
+	//Replication Fault Level
+	FaultLevel string `json:"fault_level"`
+	//Replication Record Metadata
+	RecordMetadata RecordMetadata `json:"record_metadata"`
+}
+
+type Attachment struct {
+	//Device Name
+	Device string `json:"device"`
+	//Protected Instance ID
+	ProtectedInstance string `json:"protected_instance"`
+}
+
+type RecordMetadata struct {
+	//Whether Multiattach
+	Multiattach bool `json:"multiattach"`
+	//Whether Bootable
+	Bootable bool `json:"bootable"`
+	//Volume Size
+	VolumeSize int `json:"volume_size"`
+	//Volume Type
+	VolumeType string `json:"volume_type"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a replication.
+func (r commonResult) Extract() (*Replication, error) {
+	var response Replication
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+func (r commonResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "replication")
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a Replication.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Replication.
+type GetResult struct {
+	commonResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/results_job.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/results_job.go
@@ -1,0 +1,80 @@
+package replications
+
+import (
+	"fmt"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+type JobResponse struct {
+	JobID string `json:"job_id"`
+}
+
+type JobStatus struct {
+	Status     string            `json:"status"`
+	Entities   map[string]string `json:"entities"`
+	JobID      string            `json:"job_id"`
+	JobType    string            `json:"job_type"`
+	BeginTime  string            `json:"begin_time"`
+	EndTime    string            `json:"end_time"`
+	ErrorCode  string            `json:"error_code"`
+	FailReason string            `json:"fail_reason"`
+}
+
+type JobResult struct {
+	golangsdk.Result
+}
+
+func (r JobResult) ExtractJobResponse() (*JobResponse, error) {
+	job := new(JobResponse)
+	err := r.ExtractInto(job)
+	return job, err
+}
+
+func (r JobResult) ExtractJobStatus() (*JobStatus, error) {
+	job := new(JobStatus)
+	err := r.ExtractInto(job)
+	return job, err
+}
+
+func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) error {
+
+	jobClient := *client
+	jobClient.ResourceBase = jobClient.Endpoint
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		job := new(JobStatus)
+		_, err := jobClient.Get(jobClient.ServiceURL("jobs", jobID), &job, nil)
+		if err != nil {
+			return false, err
+		}
+
+		if job.Status == "SUCCESS" {
+			return true, nil
+		}
+		if job.Status == "FAIL" {
+			err = fmt.Errorf("Job failed with code %s: %s.\n", job.ErrorCode, job.FailReason)
+			return false, err
+		}
+
+		return false, nil
+	})
+}
+
+func GetJobEntity(client *golangsdk.ServiceClient, jobId string, label string) (interface{}, error) {
+
+	jobClient := *client
+	jobClient.ResourceBase = jobClient.Endpoint
+	job := new(JobStatus)
+	_, err := jobClient.Get(jobClient.ServiceURL("jobs", jobId), &job, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if job.Status == "SUCCESS" {
+		if e := job.Entities[label]; e != "" {
+			return e, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Unexpected conversion error in GetJobEntity.")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications/urls.go
@@ -1,0 +1,11 @@
+package replications
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("replications")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("replications", id)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/service_client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/service_client.go
@@ -126,6 +126,15 @@ func (client *ServiceClient) DeleteWithResponse(url string, JSONResponse interfa
 	return client.Request("DELETE", url, opts)
 }
 
+// DeleteWithBodyResp calls `Request` with the "DELETE" HTTP verb.
+func (client *ServiceClient) DeleteWithBodyResp(url string, JSONBody interface{}, JSONResponse interface{}, opts *RequestOpts) (*http.Response, error) {
+	if opts == nil {
+		opts = new(RequestOpts)
+	}
+	client.initReqOpts(url, JSONBody, JSONResponse, opts)
+	return client.Request("DELETE", url, opts)
+}
+
 func (client *ServiceClient) setMicroversionHeader(opts *RequestOpts) {
 	switch client.Type {
 	case "compute":

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,7 +178,7 @@ github.com/hashicorp/terraform-plugin-sdk/internal/svchost
 github.com/hashicorp/terraform-plugin-sdk/internal/svchost/auth
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20191213070924-82e8f9fe298f
+# github.com/huaweicloud/golangsdk v0.0.0-20200121072916-971bfff40713
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/openstack
 github.com/huaweicloud/golangsdk/openstack/antiddos/v1/antiddos
@@ -274,6 +274,7 @@ github.com/huaweicloud/golangsdk/openstack/rts/v1/stacks
 github.com/huaweicloud/golangsdk/openstack/rts/v1/stacktemplates
 github.com/huaweicloud/golangsdk/openstack/sdrs/v1/domains
 github.com/huaweicloud/golangsdk/openstack/sdrs/v1/protectiongroups
+github.com/huaweicloud/golangsdk/openstack/sdrs/v1/replications
 github.com/huaweicloud/golangsdk/openstack/sfs/v2/shares
 github.com/huaweicloud/golangsdk/openstack/smn/v2/subscriptions
 github.com/huaweicloud/golangsdk/openstack/smn/v2/topics

--- a/website/docs/r/sdrs_replication_pair_v1.html.markdown
+++ b/website/docs/r/sdrs_replication_pair_v1.html.markdown
@@ -1,0 +1,75 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_sdrs_replication_pair_v1"
+sidebar_current: "docs-flexibleengine-resource-sdrs-replication-pair-v1"
+description: |-
+  Manages a V1 SDRS replication pair resource within FlexibleEngine.
+---
+
+# flexibleengine_sdrs_replication_pair_v1
+
+Manages a SDRS replication pair resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_sdrs_domain_v1" "domain_1" {
+  name = "SDRS_HypeDomain01"
+}
+
+resource "flexibleengine_sdrs_protectiongroup_v1" "group_1" {
+  name        = "group_1"
+  description = "test description"
+  source_availability_zone = "eu-west-0a"
+  target_availability_zone = "eu-west-0b"
+  domain_id     = data.flexibleengine_sdrs_domain_v1.domain_1.id
+  source_vpc_id = "{{ vpc_id }}"
+  dr_type       = "migration"
+}
+resource "flexibleengine_sdrs_replication_pair_v1" "replication_1" {
+  name        = "replication_1"
+  description = "test description"
+  group_id    = flexibleengine_sdrs_protectiongroup_v1.group_1.id
+  volume_id   = "{{ volume_id }}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of a replication pair. The name can contain a maximum of 64 bytes.
+  The value can contain only letters (a to z and A to Z), digits (0 to 9), decimal points (.),
+  underscores (_), and hyphens (-).
+
+* `description` - (Optional) The description of a replication pair. Changing this creates a new pair.
+
+* `group_id` - (Required) Specifies the ID of a protection group. Changing this creates a new pair.
+
+* `volume_id` - (Required) Specifies the ID of a source disk. Changing this creates a new pair.
+
+* `delete_target_volume` - (Optional) Specifies whether to delete the target disk.
+  The default value is `false`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` -  ID of the replication pair.
+
+* `fault_level` - Specifies the fault level of a replication pair.
+
+* `replication_model` - Specifies the replication mode of a replication pair. The default value is `hypermetro`.
+
+* `status` - Specifies the status of a replication pair.
+
+* `target_volume_id` - Specifies the ID of the disk in the protection availability zone.
+
+## Import
+
+Replication pairs can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_sdrs_replication_pair_v1.replication_1 43b28b66-770b-4e9e-b5c6-cfc43f0593d9
+```

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -519,6 +519,9 @@
             <li<%= sidebar_current("docs-flexibleengine-resource-sdrs-protectiongroup-v1") %>>
               <a href="/docs/providers/flexibleengine/r/sdrs_protectiongroup_v1.html">flexibleengine_sdrs_protectiongroup_v1</a>
             </li>
+            <li<%= sidebar_current("docs-flexibleengine-resource-sdrs-replication-pair-v1") %>>
+              <a href="/docs/providers/flexibleengine/r/sdrs_replication_pair_v1.html">flexibleengine_sdrs_replication_pair_v1</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
This PR supports new resource named flexibleengine_sdrs_replication_pair_v1.

The result of running test case as follows:
```shell
$ TF_ACC=1 make testacc TEST=./flexibleengine TESTARGS='-run TestAccSdrsReplicationPairV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSdrsReplicationPairV1_basic -timeout 720m
=== RUN   TestAccSdrsReplicationPairV1_basic
--- PASS: TestAccSdrsReplicationPairV1_basic (179.54s)
PASS
ok  	github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine	179.555s
```