### PR TITLE
Update test case for data.flexibleengine_networking_network_v2

### DIFF
--- a/flexibleengine/data_source_flexibleengine_networking_network_v2.go
+++ b/flexibleengine/data_source_flexibleengine_networking_network_v2.go
@@ -69,6 +69,10 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	}
 
 	pages, err := networks.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
 	allNetworks, err := networks.ExtractNetworks(pages)
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve networks: %s", err)

--- a/flexibleengine/data_source_flexibleengine_networking_network_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_networking_network_v2_test.go
@@ -2,72 +2,41 @@ package flexibleengine
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccFlexibleEngineNetworkingNetworkV2DataSource_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFlexibleEngineNetworkingNetworkV2DataSource_network,
-			},
-			{
-				Config: testAccFlexibleEngineNetworkingNetworkV2DataSource_basic,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_networking_network_v2.net"),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_networking_network_v2.net", "name", "flexibleengine_test_network"),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_networking_network_v2.net", "admin_state_up", "true"),
-				),
-			},
-		},
-	})
-}
+func TestAccNetworkingNetworkV2DataSource_basic(t *testing.T) {
+	rand.Seed(time.Now().UTC().UnixNano())
+	network := fmt.Sprintf("acc_test_network-%06x", rand.Int31n(1000000))
+	cidr := fmt.Sprintf("192.168.%d.0/24", rand.Intn(200))
 
-func TestAccFlexibleEngineNetworkingNetworkV2DataSource_subnet(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlexibleEngineNetworkingNetworkV2DataSource_network,
-			},
-			{
-				Config: testAccFlexibleEngineNetworkingNetworkV2DataSource_subnet,
+				Config: testAccNetworkingNetworkV2DataSource_basic(network, cidr),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_networking_network_v2.net"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_networking_network_v2.net_by_name"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_networking_network_v2.net_by_id"),
+					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_networking_network_v2.net_by_cidr"),
 					resource.TestCheckResourceAttr(
-						"data.flexibleengine_networking_network_v2.net", "name", "flexibleengine_test_network"),
+						"data.flexibleengine_networking_network_v2.net_by_name", "name", network),
 					resource.TestCheckResourceAttr(
-						"data.flexibleengine_networking_network_v2.net", "admin_state_up", "true"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccFlexibleEngineNetworkingNetworkV2DataSource_networkID(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccFlexibleEngineNetworkingNetworkV2DataSource_network,
-			},
-			{
-				Config: testAccFlexibleEngineNetworkingNetworkV2DataSource_networkID,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_networking_network_v2.net"),
+						"data.flexibleengine_networking_network_v2.net_by_id", "name", network),
 					resource.TestCheckResourceAttr(
-						"data.flexibleengine_networking_network_v2.net", "name", "flexibleengine_test_network"),
+						"data.flexibleengine_networking_network_v2.net_by_cidr", "name", network),
 					resource.TestCheckResourceAttr(
-						"data.flexibleengine_networking_network_v2.net", "admin_state_up", "true"),
+						"data.flexibleengine_networking_network_v2.net_by_name", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_networking_network_v2.net_by_id", "admin_state_up", "true"),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_networking_network_v2.net_by_cidr", "matching_subnet_cidr", cidr),
 				),
 			},
 		},
@@ -89,40 +58,30 @@ func testAccCheckNetworkingNetworkV2DataSourceID(n string) resource.TestCheckFun
 	}
 }
 
-const testAccFlexibleEngineNetworkingNetworkV2DataSource_network = `
+func testAccNetworkingNetworkV2DataSource_basic(name, cidr string) string {
+	return fmt.Sprintf(`
 resource "flexibleengine_networking_network_v2" "net" {
-        name = "flexibleengine_test_network"
-        admin_state_up = "true"
+  name = "%s"
+  admin_state_up = "true"
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet" {
   name = "flexibleengine_test_subnet"
-  cidr = "192.168.198.0/24"
+  cidr = "%s"
   no_gateway = true
-  network_id = "${flexibleengine_networking_network_v2.net.id}"
+  network_id = flexibleengine_networking_network_v2.net.id
 }
-`
 
-var testAccFlexibleEngineNetworkingNetworkV2DataSource_basic = fmt.Sprintf(`
-%s
-
-data "flexibleengine_networking_network_v2" "net" {
-	name = "${flexibleengine_networking_network_v2.net.name}"
+data "flexibleengine_networking_network_v2" "net_by_name" {
+	name = flexibleengine_networking_network_v2.net.name
 }
-`, testAccFlexibleEngineNetworkingNetworkV2DataSource_network)
 
-var testAccFlexibleEngineNetworkingNetworkV2DataSource_subnet = fmt.Sprintf(`
-%s
-
-data "flexibleengine_networking_network_v2" "net" {
-	matching_subnet_cidr = "${flexibleengine_networking_subnet_v2.subnet.cidr}"
+data "flexibleengine_networking_network_v2" "net_by_id" {
+	network_id = flexibleengine_networking_network_v2.net.id
 }
-`, testAccFlexibleEngineNetworkingNetworkV2DataSource_network)
 
-var testAccFlexibleEngineNetworkingNetworkV2DataSource_networkID = fmt.Sprintf(`
-%s
-
-data "flexibleengine_networking_network_v2" "net" {
-	network_id = "${flexibleengine_networking_network_v2.net.id}"
+data "flexibleengine_networking_network_v2" "net_by_cidr" {
+	matching_subnet_cidr = flexibleengine_networking_subnet_v2.subnet.cidr
 }
-`, testAccFlexibleEngineNetworkingNetworkV2DataSource_network)
+`, name, cidr)
+}


### PR DESCRIPTION
fixes #312 

the result of Testacc as follows:
```
$ make testacc TEST=./flexibleengine TESTARGS='-run TestAccNetworkingNetworkV2DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingNetworkV2DataSource_basic -timeout 720m
=== RUN   TestAccNetworkingNetworkV2DataSource_basic
--- PASS: TestAccNetworkingNetworkV2DataSource_basic (316.63s)
PASS
ok  	github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine	316.642s
```