### PR TITLE
cancel validation of storage_class in obs bucket and object

### DIFF
--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -33,9 +33,6 @@ func resourceObsBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "STANDARD",
-				ValidateFunc: validation.StringInSlice([]string{
-					"STANDARD", "WARM", "COLD",
-				}, true),
 			},
 
 			"acl": {
@@ -112,9 +109,6 @@ func resourceObsBucket() *schema.Resource {
 									"storage_class": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"WARM", "COLD",
-										}, true),
 									},
 								},
 							},
@@ -143,9 +137,6 @@ func resourceObsBucket() *schema.Resource {
 									"storage_class": {
 										Type:     schema.TypeString,
 										Required: true,
-										ValidateFunc: validation.StringInSlice([]string{
-											"WARM", "COLD",
-										}, true),
 									},
 								},
 							},
@@ -786,7 +777,7 @@ func setObsBucketStorageClass(obsClient *obs.ObsClient, d *schema.ResourceData) 
 	}
 
 	class := string(output.StorageClass)
-	d.Set("storage_class", normalizeStorageClass(class))
+	d.Set("storage_class", class)
 
 	return nil
 }
@@ -881,7 +872,7 @@ func setObsBucketLifecycleConfiguration(obsClient *obs.ObsClient, d *schema.Reso
 			for _, v := range lifecycleRule.Transitions {
 				t := make(map[string]interface{})
 				t["days"] = v.Days
-				t["storage_class"] = normalizeStorageClass(string(v.StorageClass))
+				t["storage_class"] = string(v.StorageClass)
 				transitions = append(transitions, t)
 			}
 			rule["transition"] = transitions
@@ -900,7 +891,7 @@ func setObsBucketLifecycleConfiguration(obsClient *obs.ObsClient, d *schema.Reso
 			for _, v := range lifecycleRule.NoncurrentVersionTransitions {
 				t := make(map[string]interface{})
 				t["days"] = v.NoncurrentDays
-				t["storage_class"] = normalizeStorageClass(string(v.StorageClass))
+				t["storage_class"] = string(v.StorageClass)
 				transitions = append(transitions, t)
 			}
 			rule["noncurrent_version_transition"] = transitions
@@ -1092,18 +1083,6 @@ func getObsError(action string, bucket string, err error) error {
 	} else {
 		return err
 	}
-}
-
-// normalize format of storage class
-func normalizeStorageClass(class string) string {
-	var ret string = class
-
-	if class == "STANDARD_IA" {
-		ret = "WARM"
-	} else if class == "GLACIER" {
-		ret = "COLD"
-	}
-	return ret
 }
 
 func normalizeWebsiteRoutingRules(w []obs.RoutingRule) (string, error) {

--- a/flexibleengine/resource_flexibleengine_obs_bucket_object.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_object.go
@@ -47,9 +47,6 @@ func resourceObsBucketObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ValidateFunc: validation.StringInSlice([]string{
-					"STANDARD", "WARM", "COLD",
-				}, true),
 			},
 
 			"acl": {
@@ -249,7 +246,7 @@ func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error
 	if class == "" {
 		d.Set("storage_class", "STANDARD")
 	} else {
-		d.Set("storage_class", normalizeStorageClass(class))
+		d.Set("storage_class", class)
 	}
 	d.Set("size", object.Size)
 	d.Set("etag", strings.Trim(object.ETag, `"`))

--- a/flexibleengine/resource_flexibleengine_obs_bucket_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_test.go
@@ -41,7 +41,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						resourceName, "acl", "public-read"),
 					resource.TestCheckResourceAttr(
-						resourceName, "storage_class", "WARM"),
+						resourceName, "storage_class", "GLACIER"),
 				),
 			},
 		},
@@ -310,9 +310,9 @@ func testAccObsBucketDomainName(randInt int) string {
 func testAccObsBucket_basic(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-    storage_class = "STANDARD"
-	acl = "private"
+  bucket = "tf-test-bucket-%d"
+  storage_class = "STANDARD"
+  acl = "private"
 }
 `, randInt)
 }
@@ -320,9 +320,9 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucket_basic_update(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-    storage_class = "WARM"
-	acl = "public-read"
+  bucket = "tf-test-bucket-%d"
+  storage_class = "GLACIER"
+  acl = "public-read"
 }
 `, randInt)
 }
@@ -330,14 +330,14 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucketConfigWithTags(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
 
-	tags = {
-		name = "tf-test-bucket-%d"
-        foo = "bar"
-        key1 = "value1"
-	}
+  tags = {
+    name = "tf-test-bucket-%d"
+    foo = "bar"
+    key1 = "value1"
+  }
 }
 `, randInt, randInt)
 }
@@ -345,9 +345,9 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucketConfigWithVersioning(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
-	versioning = true
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
+  versioning = true
 }
 `, randInt)
 }
@@ -355,9 +355,9 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucketConfigWithDisableVersioning(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
-	versioning = false
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
+  versioning = false
 }
 `, randInt)
 }
@@ -365,18 +365,18 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucketConfigWithLogging(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "log_bucket" {
-	bucket = "tf-test-log-bucket-%d"
-	acl = "log-delivery-write"
-    force_destroy = "true"
+  bucket = "tf-test-log-bucket-%d"
+  acl = "log-delivery-write"
+  force_destroy = "true"
 }
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
 
-	logging {
-		target_bucket = flexibleengine_obs_bucket.log_bucket.id
-		target_prefix = "log/"
-	}
+  logging {
+    target_bucket = flexibleengine_obs_bucket.log_bucket.id
+    target_prefix = "log/"
+  }
 }
 `, randInt, randInt)
 }
@@ -384,55 +384,55 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucketConfigWithLifecycle(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "private"
-	versioning = true
+  bucket = "tf-test-bucket-%d"
+  acl = "private"
+  versioning = true
 
-	lifecycle_rule {
-		name = "rule1"
-		prefix = "path1/"
-		enabled = true
+  lifecycle_rule {
+    name = "rule1"
+    prefix = "path1/"
+    enabled = true
 
-		expiration {
-			days = 365
-		}
-	}
-	lifecycle_rule {
-		name = "rule2"
-		prefix = "path2/"
-		enabled = true
+    expiration {
+      days = 365
+    }
+  }
+  lifecycle_rule {
+    name = "rule2"
+    prefix = "path2/"
+    enabled = true
 
-		expiration {
-			days = 365
-		}
+    expiration {
+      days = 365
+    }
 
-		transition {
-			days = 30
-			storage_class = "WARM"
-		}
-		transition {
-			days = 180
-			storage_class = "COLD"
-		}
-	}
-	lifecycle_rule {
-		name = "rule3"
-		prefix = "path3/"
-		enabled = true
+    transition {
+      days = 30
+      storage_class = "STANDARD_IA"
+    }
+    transition {
+      days = 180
+      storage_class = "GLACIER"
+    }
+  }
+  lifecycle_rule {
+    name = "rule3"
+    prefix = "path3/"
+    enabled = true
 
-		noncurrent_version_expiration {
-			days = 365
-		}
+    noncurrent_version_expiration {
+      days = 365
+    }
 
-		noncurrent_version_transition {
-			days = 60
-			storage_class = "WARM"
-		}
-		noncurrent_version_transition {
-			days = 180
-			storage_class = "COLD"
-		}
-	}
+    noncurrent_version_transition {
+      days = 60
+      storage_class = "STANDARD_IA"
+    }
+    noncurrent_version_transition {
+      days = 180
+      storage_class = "GLACIER"
+    }
+  }
 }
 `, randInt)
 }
@@ -440,13 +440,13 @@ resource "flexibleengine_obs_bucket" "bucket" {
 func testAccObsBucketWebsiteConfigWithRoutingRules(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "public-read"
+  bucket = "tf-test-bucket-%d"
+  acl = "public-read"
 
-	website {
-		index_document = "index.html"
-		error_document = "error.html"
-		routing_rules = <<EOF
+  website {
+    index_document = "index.html"
+    error_document = "error.html"
+    routing_rules = <<EOF
 [{
 	"Condition": {
 		"KeyPrefixEquals": "docs/"
@@ -456,7 +456,7 @@ resource "flexibleengine_obs_bucket" "bucket" {
 	}
 }]
 EOF
-	}
+  }
 }
 `, randInt)
 }
@@ -464,16 +464,16 @@ EOF
 func testAccObsBucketConfigWithCORS(randInt int) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_obs_bucket" "bucket" {
-	bucket = "tf-test-bucket-%d"
-	acl = "public-read"
+  bucket = "tf-test-bucket-%d"
+  acl = "public-read"
 
-	cors_rule {
-		allowed_headers = ["*"]
-		allowed_methods = ["PUT","POST"]
-		allowed_origins = ["https://www.example.com"]
-		expose_headers  = ["x-amz-server-side-encryption","ETag"]
-		max_age_seconds = 3000
-	}
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["PUT","POST"]
+    allowed_origins = ["https://www.example.com"]
+    expose_headers  = ["x-amz-server-side-encryption","ETag"]
+    max_age_seconds = 3000
+  }
 }
 `, randInt)
 }

--- a/website/docs/r/obs_bucket.html.markdown
+++ b/website/docs/r/obs_bucket.html.markdown
@@ -111,11 +111,11 @@ resource "flexibleengine_obs_bucket" "bucket" {
     }
     transition {
       days = 60
-      storage_class = "WARM"
+      storage_class = "STANDARD_IA"
     }
     transition {
       days = 180
-      storage_class = "COLD"
+      storage_class = "GLACIER"
     }
   }
 
@@ -129,11 +129,11 @@ resource "flexibleengine_obs_bucket" "bucket" {
     }
     noncurrent_version_transition {
       days = 30
-      storage_class = "WARM"
+      storage_class = "STANDARD_IA"
     }
     noncurrent_version_transition {
       days = 60
-      storage_class = "COLD"
+      storage_class = "GLACIER"
     }
   }
 }
@@ -151,9 +151,11 @@ The following arguments are supported:
 	* The name cannot be an IP address.
 	* If the name contains any periods (.), a security certificate verification message may appear when you access the bucket or its objects by entering a domain name.
 
-* `storage_class` - (Optional) Specifies the storage class of the bucket. OBS provides three storage classes: "STANDARD", "WARM" (Infrequent Access) and "COLD" (Archive). Defaults to `STANDARD`.
+* `storage_class` - (Optional) Specifies the storage class of the bucket. OBS provides three storage classes:
+    "STANDARD", "STANDARD_IA" (Infrequent Access) and "GLACIER" (Archive). Defaults to `STANDARD`.
 
-* `acl` - (Optional) Specifies the ACL policy for a bucket. The predefined common policies are as follows: "private", "public-read", "public-read-write" and "log-delivery-write". Defaults to `private`.
+* `acl` - (Optional) Specifies the ACL policy for a bucket. The predefined common policies are as follows:
+    "private", "public-read", "public-read-write" and "log-delivery-write". Defaults to `private`.
 
 * `versioning` - (Optional) Whether enable versioning. Once you version-enable a bucket, it can never return to an unversioned state.
   You can, however, suspend versioning on that bucket.
@@ -163,7 +165,8 @@ The following arguments are supported:
 * `cors_rule` - (Optional) A rule of Cross-Origin Resource Sharing (documented below).
 * `lifecycle_rule` - (Optional) A configuration of object lifecycle management (documented below).
 
-* `force_destroy` - (Optional) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. Default to `false`.
+* `force_destroy` - (Optional) A boolean that indicates all objects should be deleted from the bucket so that
+    the bucket can be destroyed without error. Default to `false`.
 
 * `region` - (Optional) If specified, the region this bucket should reside in. Otherwise, the region used by the provider.
 
@@ -219,9 +222,9 @@ The `lifecycle_rule` object supports the following:
   The prefix cannot start or end with a slash (/), cannot have consecutive slashes (/), and cannot contain the following special characters: \:*?"<>|.
 
 * `expiration` - (Optional) Specifies a period when objects that have been last updated are automatically deleted. (documented below).
-* `transition` - (Optional) Specifies a period when objects that have been last updated are automatically transitioned to `WARM` or `COLD` storage class (documented below).
+* `transition` - (Optional) Specifies a period when objects that have been last updated are automatically transitioned to `STANDARD_IA` or `GLACIER` storage class (documented below).
 * `noncurrent_version_expiration` - (Optional) Specifies a period when noncurrent object versions are automatically deleted. (documented below).
-* `noncurrent_version_transition` - (Optional) Specifies a period when noncurrent object versions are automatically transitioned to `WARM` or `COLD` storage class (documented below).
+* `noncurrent_version_transition` - (Optional) Specifies a period when noncurrent object versions are automatically transitioned to `STANDARD_IA` or `GLACIER` storage class (documented below).
 
 At least one of `expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition` must be specified.
 
@@ -232,8 +235,9 @@ The `expiration` object supports the following
 
 The `transition` object supports the following
 
-* `days` (Required) Specifies the number of days when objects that have been last updated are automatically transitioned to the specified storage class.
-* `storage_class` - (Required) The class of storage used to store the object. Only `WARM` and `COLD` are supported.
+* `days` (Required) Specifies the number of days when objects that have been last updated are automatically
+    transitioned to the specified storage class.
+* `storage_class` - (Required) The class of storage used to store the object. Only "STANDARD_IA" and "GLACIER" are supported.
 
 The `noncurrent_version_expiration` object supports the following
 
@@ -241,8 +245,9 @@ The `noncurrent_version_expiration` object supports the following
 
 The `noncurrent_version_transition` object supports the following
 
-* `days` (Required) Specifies the number of days when noncurrent object versions are automatically transitioned to the specified storage class.
-* `storage_class` - (Required) The class of storage used to store the object. Only `WARM` and `COLD` are supported.
+* `days` (Required) Specifies the number of days when noncurrent object versions are automatically
+    transitioned to the specified storage class.
+* `storage_class` - (Required) The class of storage used to store the object. Only "STANDARD_IA" and "GLACIER" are supported.
 
 ## Attributes Reference
 


### PR DESCRIPTION
fixes #337 

test results:
```
$ make testacc TEST=./flexibleengine TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_basic -timeout 720m
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (95.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 95.463s

 $ make testacc TEST=./flexibleengine TESTARGS='-run TestAccObsBucket_lifecycle'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_lifecycle -timeout 720m
=== RUN   TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_lifecycle (80.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 80.053s

$ make testacc TEST=./flexibleengine TESTARGS='-run TestAccObsBucketObject_source'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucketObject_source -timeout 720m
=== RUN   TestAccObsBucketObject_source
--- PASS: TestAccObsBucketObject_source (96.09s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 96.103s
```