### PR TITLE
Add css snapshot resource and docs

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -295,6 +295,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_vbs_backup_v2":                      resourceVBSBackupV2(),
 			"flexibleengine_antiddos_v1":                        resourceAntiDdosV1(),
 			"flexibleengine_css_cluster_v1":                     resourceCssClusterV1(),
+			"flexibleengine_css_snapshot_v1":                    resourceCssSnapshotV1(),
 			"flexibleengine_cts_tracker_v1":                     resourceCTSTrackerV1(),
 			"flexibleengine_cce_node_v3":                        resourceCCENodeV3(),
 			"flexibleengine_cce_cluster_v3":                     resourceCCEClusterV3(),

--- a/flexibleengine/resource_flexibleengine_css_snapshot_v1.go
+++ b/flexibleengine/resource_flexibleengine_css_snapshot_v1.go
@@ -1,0 +1,218 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/css/v1/snapshots"
+)
+
+func resourceCssSnapshotV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceCssSnapshotV1Create,
+		Read:   resourceCssSnapshotV1Read,
+		Delete: resourceCssSnapshotV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: resourceCssSnapshotImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"cluster_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"indices": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cluster_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"backup_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceCssSnapshotV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	cssClient, err := config.sdkClient(GetRegion(d, config), "css")
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine CSS client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	createOpts := &snapshots.CreateOpts{
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+		Indices:     d.Get("indices").(string),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	snap, err := snapshots.Create(cssClient, createOpts, clusterId).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine CSS snapshot: %s", err)
+	}
+
+	// Store the snapshot ID
+	d.SetId(snap.ID)
+
+	log.Printf("[DEBUG] Waiting for snapshot (%s) to complete", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"BUILDING"},
+		Target:     []string{"COMPLETED"},
+		Refresh:    cssSnapshotStateRefreshFunc(cssClient, clusterId, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      10 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for snapshot (%s) to complete: %s",
+			d.Id(), err)
+	}
+
+	return resourceCssSnapshotV1Read(d, meta)
+}
+
+func resourceCssSnapshotV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	cssClient, err := config.sdkClient(GetRegion(d, config), "css")
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine CSS client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	snapList, err := snapshots.List(cssClient, clusterId).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "snapshot")
+	}
+
+	// find the snapshot by ID
+	var snap snapshots.Snapshot
+	for _, v := range snapList {
+		if v.ID == d.Id() {
+			snap = v
+			break
+		}
+	}
+	if snap.ID == "" {
+		log.Printf("[INFO] the snapshot %s does not exist", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Retrieved the sanpshot %s: %+v", d.Id(), snap)
+
+	d.Set("name", snap.Name)
+	d.Set("description", snap.Description)
+	d.Set("status", snap.Status)
+	d.Set("indices", snap.Indices)
+	d.Set("cluster_id", snap.ClusterID)
+	d.Set("cluster_name", snap.ClusterName)
+	// Method is more suitable for backup_type
+	d.Set("backup_type", snap.Method)
+
+	return nil
+}
+
+func resourceCssSnapshotV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	cssClient, err := config.sdkClient(GetRegion(d, config), "css")
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine CSS storage client: %s", err)
+	}
+
+	clusterId := d.Get("cluster_id").(string)
+	if err := snapshots.Delete(cssClient, clusterId, d.Id()).ExtractErr(); err != nil {
+		return CheckDeleted(d, err, "snapshot")
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// cssSnapshotStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch
+// an CSS cluster snapshot.
+func cssSnapshotStateRefreshFunc(client *golangsdk.ServiceClient, clusterId, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		snapList, err := snapshots.List(client, clusterId).Extract()
+		if err != nil {
+			return nil, "FAILED", err
+		}
+
+		// find the snapshot by ID
+		var snap snapshots.Snapshot
+		for _, v := range snapList {
+			if v.ID == id {
+				snap = v
+				break
+			}
+		}
+
+		if snap.ID == "" {
+			return nil, "NOTEXIST", fmt.Errorf("The specified snapshot %s not exist", id)
+		}
+
+		return snap, snap.Status, nil
+	}
+}
+
+func resourceCssSnapshotImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmt.Errorf("Invalid format specified for CSS snapshot. Format must be <cluster id>/<snapshot id>")
+		return nil, err
+	}
+	clusterID := parts[0]
+	snapshotID := parts[1]
+
+	config := meta.(*Config)
+	client, err := config.sdkClient(GetRegion(d, config), "css")
+	if err != nil {
+		return nil, fmt.Errorf("Error creating css client, err=%s", err)
+	}
+
+	// check the css cluster whether exists
+	d.SetId(clusterID)
+	if _, err := sendCssClusterV1ReadRequest(d, client); err != nil {
+		return nil, err
+	}
+
+	d.Set("cluster_id", clusterID)
+	d.SetId(snapshotID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/flexibleengine/resource_flexibleengine_css_snapshot_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_css_snapshot_v1_test.go
@@ -1,0 +1,134 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/css/v1/snapshots"
+)
+
+func TestAccCssSnapshotV1_basic(t *testing.T) {
+	rand := acctest.RandString(5)
+	resourceKey := "flexibleengine_css_snapshot_v1.snapshot"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCssSnapshotV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssSnapshotV1_basic(rand),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssSnapshotV1Exists(),
+					resource.TestCheckResourceAttr(
+						resourceKey, "name", fmt.Sprintf("snapshot-%s", rand)),
+					resource.TestCheckResourceAttr(
+						resourceKey, "status", "COMPLETED"),
+					resource.TestCheckResourceAttr(
+						resourceKey, "backup_type", "manual"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckCssSnapshotV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	client, err := config.sdkClient(OS_REGION_NAME, "css")
+	if err != nil {
+		return fmt.Errorf("Error creating css client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_css_snapshot_v1" {
+			continue
+		}
+
+		clusterId := rs.Primary.Attributes["cluster_id"]
+		snapList, err := snapshots.List(client, clusterId).Extract()
+		if err != nil {
+			return err
+		}
+
+		for _, v := range snapList {
+			if v.ID == rs.Primary.ID {
+				return fmt.Errorf("flexibleengine_css_snapshot_v1 %s still exists", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCssSnapshotV1Exists() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		client, err := config.sdkClient(OS_REGION_NAME, "css")
+		if err != nil {
+			return fmt.Errorf("Error creating css client, err=%s", err)
+		}
+
+		rs, ok := s.RootModule().Resources["flexibleengine_css_snapshot_v1.snapshot"]
+		if !ok {
+			return fmt.Errorf("Error checking flexibleengine_css_snapshot_v1.snapshot exist, err=not found this resource")
+		}
+
+		clusterId := rs.Primary.Attributes["cluster_id"]
+		snapList, err := snapshots.List(client, clusterId).Extract()
+		if err != nil {
+			return err
+		}
+
+		for _, v := range snapList {
+			if v.ID == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("flexibleengine_css_snapshot_v1 %s is not exist", rs.Primary.ID)
+	}
+}
+
+func testAccCssSnapshotV1_basic(val string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_secgroup_v2" "secgroup" {
+  name = "terraform_test_sg-%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "flexibleengine_css_cluster_v1" "cluster" {
+  name = "tf-css-cluster-%s"
+  engine_version = "7.1.1"
+  node_number    = 1
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "COMMON"
+      size = 40
+    }
+    availability_zone = "%s"
+  }
+
+  backup_strategy {
+    start_time = "00:00 GMT+03:00"
+    prefix     = "snapshot"
+    keep_days  = 14
+  }
+}
+
+resource "flexibleengine_css_snapshot_v1" "snapshot" {
+  name        = "snapshot-%s"
+  description = "a snapshot created by terraform acctest"
+  cluster_id  = flexibleengine_css_cluster_v1.cluster.id
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE, val)
+}

--- a/website/docs/r/css_snapshot_v1.html.markdown
+++ b/website/docs/r/css_snapshot_v1.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_css_snapshot_v1"
+sidebar_current: "docs-flexibleengine-resource-css-snapshot-v1"
+description: |-
+ CSS cluster snapshot management
+---
+
+# flexibleengine\_css\_cluster\_v1
+
+CSS cluster snapshot management
+
+## Example Usage
+
+### create a snapshot
+
+```hcl
+resource "flexibleengine_css_snapshot_v1" "snapshot" {
+  name       = "terraform_test_cluster"
+  cluster_id = var.css_cluster_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies the snapshot name. The snapshot name must
+  start with a letter and contains 4 to 64 characters consisting of only
+  lowercase letters, digits, hyphens (-), and underscores (_).
+  Changing this parameter will create a new resource.
+
+* `cluster_id` - (Required) Specifies ID of the CSS cluster where index data is to be backed up.
+  Changing this parameter will create a new resource.
+
+* `indices` - (Optional) Specifies the name of the index to be backed up. Multiple index names
+  are separated by commas (,). By default, data of all indices is backed up. You can use the
+  asterisk (*) to back up data of certain indices. For example, if you enter 2018-06*, then
+  data of indices with the name prefix of 2018-06 will be backed up.
+  The value contains 0 to 1024 characters. Uppercase letters, spaces, and certain special
+  characters (including "\<|>/?) are not allowed.
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional) Specifies the description of a snapshot. The value contains 0 to 256 characters, and angle brackets (<) and (>) are not allowed.
+  Changing this parameter will create a new resource.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `status` - Indicates the snapshot status.
+
+* `cluster_name` - Indicates the CSS cluster name.
+
+* `backup_type` - Indicates the snapshot creation mode, the value should be "manual" or "automated".
+
+
+## Import
+
+This resource can be imported by specifying the CSS cluster ID and snapshot ID
+separated by a slash, e.g.:
+
+```
+$ terraform import flexibleengine_css_snapshot_v1.snapshot_1 <cluster_id>/<snapshot_id>
+```

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -243,6 +243,10 @@
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-flexibleengine-resource-css-cluster-v1") %>>
               <a href="/docs/providers/flexibleengine/r/css_cluster_v1.html">flexibleengine_css_cluster_v1</a>
+            </li>
+            <li<%= sidebar_current("docs-flexibleengine-resource-css-snapshot-v1") %>>
+              <a href="/docs/providers/flexibleengine/r/css_snapshot_v1.html">flexibleengine_css_snapshot_v1</a>
+            </li>
           </ul>
         </li>
 
@@ -251,6 +255,7 @@
           <ul class="nav nav-visible">
             <li<%= sidebar_current("docs-flexibleengine-resource-cts-tracker-v1") %>>
               <a href="/docs/providers/flexibleengine/r/cts_tracker_v1.html">flexibleengine_cts_tracker_v1</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
the resource named `flexibleengine_css_snapshot_v1` which was used to create and delete an css snapshot manually.
the testing result as follows:

```
$ make testacc TEST=./flexibleengine TESTARGS='-run TestAccCssSnapshotV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCssSnapshotV1_basic -timeout 720m
=== RUN   TestAccCssSnapshotV1_basic
--- PASS: TestAccCssSnapshotV1_basic (946.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 946.978s
```