### PR TITLE
set 'access_to' to be optional in sfs file system

### DIFF
--- a/flexibleengine/resource_flexibleengine_sfs_file_system_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_sfs_file_system_v2_test.go
@@ -28,7 +28,7 @@ func TestAccSFSFileSystemV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"flexibleengine_sfs_file_system_v2.sfs_1", "status", "available"),
 					resource.TestCheckResourceAttr(
-						"flexibleengine_sfs_file_system_v2.sfs_1", "size", "1"),
+						"flexibleengine_sfs_file_system_v2.sfs_1", "size", "10"),
 					resource.TestCheckResourceAttr(
 						"flexibleengine_sfs_file_system_v2.sfs_1", "access_level", "rw"),
 				),
@@ -44,9 +44,35 @@ func TestAccSFSFileSystemV2_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"flexibleengine_sfs_file_system_v2.sfs_1", "status", "available"),
 					resource.TestCheckResourceAttr(
-						"flexibleengine_sfs_file_system_v2.sfs_1", "size", "1"),
+						"flexibleengine_sfs_file_system_v2.sfs_1", "size", "10"),
 					resource.TestCheckResourceAttr(
 						"flexibleengine_sfs_file_system_v2.sfs_1", "access_level", "rw"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccSFSFileSystemV2_without_rule(t *testing.T) {
+	var share shares.Share
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSFSFileSystemV2Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSFSFileSystemV2_without_rule,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSFSFileSystemV2Exists("flexibleengine_sfs_file_system_v2.sfs_1", &share),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sfs_file_system_v2.sfs_1", "name", "sfs-test-no-rules"),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sfs_file_system_v2.sfs_1", "share_proto", "NFS"),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sfs_file_system_v2.sfs_1", "status", "unavailable"),
+					resource.TestCheckResourceAttr(
+						"flexibleengine_sfs_file_system_v2.sfs_1", "size", "10"),
 				),
 			},
 		},
@@ -126,43 +152,52 @@ func testAccCheckSFSFileSystemV2Exists(n string, share *shares.Share) resource.T
 
 var testAccSFSFileSystemV2_basic = fmt.Sprintf(`
 resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="sfs-test1"
-  	availability_zone="%s"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto  = "NFS"
+  size         = 10
+  name         = "sfs-test1"
+  description  = "sfs_c2c_test-file"
+  access_to    = "%s"
+  access_type  = "cert"
+  access_level = "rw"
+  availability_zone = "%s"
 }
-`, OS_AVAILABILITY_ZONE, OS_VPC_ID)
+`, OS_VPC_ID, OS_AVAILABILITY_ZONE)
 
 var testAccSFSFileSystemV2_update = fmt.Sprintf(`
 resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="sfs-test2"
-  	availability_zone="%s"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto  = "NFS"
+  size         = 10
+  name         = "sfs-test2"
+  description  = "sfs_c2c_test-file"
+  access_to    = "%s"
+  access_type  = "cert"
+  access_level = "rw"
+  availability_zone = "%s"
 }
-`, OS_AVAILABILITY_ZONE, OS_VPC_ID)
+`, OS_VPC_ID, OS_AVAILABILITY_ZONE)
+
+const testAccSFSFileSystemV2_without_rule = `
+resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "sfs-test-no-rules"
+  description = "sfs_c2c_test-file"
+}
+`
 
 var testAccSFSFileSystemV2_timeout = fmt.Sprintf(`
 resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
-	share_proto = "NFS"
-	size=1
-	name="sfs-test1"
-  	availability_zone="%s"
-	access_to="%s"
-  	access_type="cert"
-  	access_level="rw"
-	description="sfs_c2c_test-file"
+  share_proto  = "NFS"
+  size         = 10
+  name         = "sfs-test1"
+  description  = "sfs_c2c_test-file"
+  access_to    = "%s"
+  access_type  = "cert"
+  access_level = "rw"
+  availability_zone = "%s"
 
   timeouts {
     create = "5m"
     delete = "5m"
   }
-}`, OS_AVAILABILITY_ZONE, OS_VPC_ID)
+}`, OS_VPC_ID, OS_AVAILABILITY_ZONE)

--- a/website/docs/r/sfs_file_system_v2.html.md
+++ b/website/docs/r/sfs_file_system_v2.html.md
@@ -12,26 +12,20 @@ Provides an Shared File System (SFS) resource.
 
 ## Example Usage
 
- ```hcl
-    variable "share_name" { }
+```hcl
+variable "share_name" { }
+variable "share_description" { }
+variable "vpc_id" { }
 
-    variable "share_description" { }
-
-    variable "vpc_id" { }
-
-    resource "flexibleengine_sfs_file_system_v2" "share-file"
-    {
-            size = 50
-            name = "${var.share_name}"
-            access_to = "${var.vpc_id}"
-            access_level = "rw"
-            description = "${var.share_description}"
-            metadata = {
-                "type"="nfs"
-            }
-
-    }
- ```
+resource "flexibleengine_sfs_file_system_v2" "share-file" {
+  name         = var.share_name
+  size         = 100
+  share_proto  = "NFS"
+  access_level = "rw"
+  access_to    = var.vpc_id
+  description  = var.share_description
+}
+```
 
 ## Argument Reference
 The following arguments are supported:
@@ -46,15 +40,27 @@ The following arguments are supported:
 
 * `is_public` - (Optional) The level of visibility for the shared file system.
 
-* `metadata` - (Optional) Metadata key and value pairs as a dictionary of strings.Changing this will create a new resource.
+* `metadata` - (Optional) Metadata key and value pairs as a dictionary of strings. Changing this will create a new resource.
 
-* `availability_zone` - (Optional) The availability zone name.Changing this parameter will create a new resource.
+* `availability_zone` - (Optional) The availability zone name. Changing this parameter will create a new resource.
 
-* `access_level` - (Required) The access level of the shared file system. Changing this will create a new access rule.
+* `access_level` - (Optional) Specifies the access level of the shared file system. Possible values are *ro* (read-only)
+    and *rw* (read-write). The default value is *rw* (read/write). Changing this will create a new access rule.
 
-* `access_type` - (Optional) The type of the share access rule. Changing this will create a new access rule.
+* `access_type` - (Optional) Specifies the type of the share access rule. The default value is *cert*.
+    Changing this will create a new access rule.
 
-* `access_to` - (Required) The access that the back end grants or denies. Changing this will create a new access rule
+* `access_to` - (Optional) Specifies the value that defines the access rule. The value contains 1 to 255 characters.
+    Changing this will create a new access rule. The value varies according to the scenario:
+    - Set the VPC ID in VPC authorization scenarios.
+    - Set this parameter in IP address authorization scenario.
+
+        For an NFS shared file system, the value in the format of *VPC_ID#IP_address#priority#user_permission*. For example,
+        0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#100#all_squash,root_squash.
+
+        For a CIFS shared file system, the value in the format of *VPC_ID#IP_address#priority*. For example,
+        0157b53f-4974-4e80-91c9-098532bcaf00#2.2.2.2/16#0.
+
 
 ## Attributes Reference
 In addition to all arguments above, the following attributes are exported:
@@ -63,7 +69,8 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the shared file system.
 
-* `share_type` - The storage service type assigned for the shared file system, such as high-performance storage (composed of SSDs) and large-capacity storage (composed of SATA disks).
+* `share_type` - The storage service type assigned for the shared file system, such as high-performance
+    storage (composed of SSDs) and large-capacity storage (composed of SATA disks).
 
 * `volume_type` - The volume type.
 
@@ -75,6 +82,12 @@ In addition to all arguments above, the following attributes are exported:
 
 * `access_rules_status` - The status of the share access rule.
 
+* `access_rules` - All access rules of the shared file system. The object includes the following:
+    - `access_rule_id` - The UUID of the share access rule.
+    - `access_level` - The access level of the shared file system
+    - `access_type` - The type of the share access rule.
+    - `access_to` - The value that defines the access rule.
+    - `status` - The status of the share access rule.
 
 ## Import
 


### PR DESCRIPTION
improve for flexibleengine_sfs_file_system_v2 resource:
- set 'access_to' to be optional in sfs file system
- add 'access_rules' attribute to show all access rules

the testacc results as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSFSFileSystemV2_basic -timeout 720m
=== RUN   TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (73.55s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 73.564s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSFSFileSystemV2_without_rule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSFSFileSystemV2_without_rule -timeout 720m
=== RUN   TestAccSFSFileSystemV2_without_rule
--- PASS: TestAccSFSFileSystemV2_without_rule (47.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 47.021s
```